### PR TITLE
Improve property card resiliency when mock images fail

### DIFF
--- a/components/PropertyCard.tsx
+++ b/components/PropertyCard.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import { Listing } from '@/types/listing';
 import { Button } from '@/ui/Button';
-import { ArrowLeft, Bath, BedDouble, Ruler } from 'lucide-react';
+import { ArrowLeft, Bath, BedDouble, ImageOff, Ruler } from 'lucide-react';
 import { cn } from '@/utils/cn';
 
 interface PropertyCardProps {
@@ -11,6 +14,16 @@ interface PropertyCardProps {
 }
 
 export function PropertyCard({ listing, highlight = false }: PropertyCardProps) {
+  const [imageStatus, setImageStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  const shouldShowImage = useMemo(() => {
+    return Boolean(listing.image) && imageStatus !== 'error';
+  }, [listing.image, imageStatus]);
+
+  useEffect(() => {
+    setImageStatus('loading');
+  }, [listing.image]);
+
   return (
     <article
       className={cn(
@@ -18,14 +31,32 @@ export function PropertyCard({ listing, highlight = false }: PropertyCardProps) 
         highlight && 'border-primary-200'
       )}
     >
-      <div className="relative h-64 w-full">
-        <Image
-          src={listing.image}
-          alt={listing.title}
-          fill
-          className="object-cover"
-          sizes="(max-width: 768px) 100vw, 33vw"
-        />
+      <div className="relative h-64 w-full overflow-hidden">
+        {shouldShowImage ? (
+          <>
+            <Image
+              src={listing.image}
+              alt={listing.title}
+              fill
+              sizes="(max-width: 768px) 100vw, 33vw"
+              className={cn(
+                'object-cover transition-opacity duration-500',
+                imageStatus === 'ready' ? 'opacity-100' : 'opacity-0'
+              )}
+              onLoad={() => setImageStatus('ready')}
+              onError={() => setImageStatus('error')}
+              priority={highlight}
+            />
+            {imageStatus !== 'ready' ? (
+              <div className="absolute inset-0 animate-pulse bg-gradient-to-br from-slate-200 via-slate-100 to-primary-50" />
+            ) : null}
+          </>
+        ) : (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-gradient-to-br from-slate-200 via-slate-100 to-primary-50 text-slate-600">
+            <ImageOff className="h-8 w-8" aria-hidden="true" />
+            <span className="mt-2 text-xs font-semibold">پیش‌نمایش در دسترس نیست</span>
+          </div>
+        )}
         {listing.featured ? (
           <span className="absolute right-4 top-4 rounded-full bg-white/90 px-4 py-1 text-xs font-semibold text-primary-600">
             ویژه

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,7 +25,7 @@ const config: Config = {
         },
         accent: '#ff9f1c',
         dark: '#12131a',
-        muted: '#6b7280'
+        muted: '#4b5563'
       },
       fontFamily: {
         sans: ['var(--font-vazirmatn)', 'Vazirmatn', 'system-ui', 'sans-serif']


### PR DESCRIPTION
## Summary
- add resilient image handling with loading state and graceful fallback messaging on the property card
- tweak the shared muted color token for improved text contrast across UI surfaces

## Testing
- npm run lint *(fails: Next.js CLI unavailable in sandbox because dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e17582be308333b289325f4b39e6e8